### PR TITLE
Reduce runtime for warping to template, by initial downsampling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -473,6 +473,29 @@ webencodings = "*"
 css = ["tinycss2 (>=1.1.0,<1.3)"]
 
 [[package]]
+name = "bokeh"
+version = "3.4.1"
+description = "Interactive plots and applications in the browser from Python"
+category = "main"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "bokeh-3.4.1-py3-none-any.whl", hash = "sha256:1e3c502a0a8205338fc74dadbfa321f8a0965441b39501e36796a47b4017b642"},
+    {file = "bokeh-3.4.1.tar.gz", hash = "sha256:d824961e4265367b0750ce58b07e564ad0b83ca64b335521cd3421e9b9f10d89"},
+]
+
+[package.dependencies]
+contourpy = ">=1.2"
+Jinja2 = ">=2.9"
+numpy = ">=1.16"
+packaging = ">=16.8"
+pandas = ">=1.2"
+pillow = ">=7.1.0"
+PyYAML = ">=3.10"
+tornado = ">=6.2"
+xyzservices = ">=2021.09.1"
+
+[[package]]
 name = "botocore"
 version = "1.34.69"
 description = "Low-level, data-driven core of boto 3."
@@ -831,7 +854,7 @@ files = [
 name = "contourpy"
 version = "1.2.1"
 description = "Python library for calculating contours of 2D quadrilateral grids"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.9"
 files = [
@@ -6313,6 +6336,18 @@ files = [
 ]
 
 [[package]]
+name = "xyzservices"
+version = "2024.4.0"
+description = "Source of XYZ tiles providers"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "xyzservices-2024.4.0-py3-none-any.whl", hash = "sha256:b83e48c5b776c9969fffcfff57b03d02b1b1cd6607a9d9c4e7f568b01ef47f4c"},
+    {file = "xyzservices-2024.4.0.tar.gz", hash = "sha256:6a04f11487a6fb77d92a98984cd107fbd9157fd5e65f929add9c3d6e604ee88c"},
+]
+
+[[package]]
 name = "yarl"
 version = "1.9.4"
 description = "Yet another URL library"
@@ -6507,4 +6542,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "83854bc77ce8f66debab7bf5c3ce2ce5497bb7d9cbad08592bcf658138a3eac5"
+content-hash = "2429d5819d1f2ff3e8ce5f760cba5b03ceb090e3579ac30c4ed8583741e73282"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ ome-zarr = "^0.9.0"
 pybids = "^0.16.5"
 sparse = "^0.15.1"
 zarrnii = "^0.1.1a1"
+bokeh = "^3.4.1"
 
 [tool.poetry.scripts]
 spimquant = "spimquant.run:main"

--- a/spimquant/workflow/rules/templatereg.smk
+++ b/spimquant/workflow/rules/templatereg.smk
@@ -323,8 +323,9 @@ rule deform_zarr_to_template_nii:
         ref_nii=bids_tpl(root=root, template="{template}", suffix="anat.nii.gz"),
     params:
         flo_opts={"level": 2}, #downsampling level to use (TODO: set this automatically based on ref resolution?)
-        downsample_opts={'along_z': 6}, #could also be determined automatically 
-        ref_opts={"chunks": (1, 20, 20, 20)},
+        do_downsample=True, #whether to perform further downsampling before transforming
+        downsample_opts={'along_z': 4}, #could also be determined automatically 
+        ref_opts={"chunks": (1, 100, 100, 100)},
     output:
         nii=bids(
             root=root,
@@ -335,7 +336,7 @@ rule deform_zarr_to_template_nii:
             suffix="SPIM.nii",
             **inputs["spim"].wildcards
         ),
-    threads: 4
+    threads: 32
     container: None
     script:
         "../scripts/deform_to_template_nii.py"
@@ -348,6 +349,9 @@ rule deform_to_template_nii_zoomed:
         warp_nii=rules.deform_reg.output.warp,
         ref_nii=bids_tpl(root=root, template="{template}", suffix="anat.nii.gz"),
     params:
+        flo_opts={"level": 1}, #downsampling level to use (TODO: set this automatically based on ref resolution?)
+        do_downsample=False, #whether to perform further downsampling before transforming
+        downsample_opts={'along_z': 4}, #could also be determined automatically 
         ref_opts=lambda wildcards: {
             "chunks": (1, 50, 50, 50),
             "zooms": (

--- a/spimquant/workflow/scripts/affine_to_template_nii.py
+++ b/spimquant/workflow/scripts/affine_to_template_nii.py
@@ -11,7 +11,7 @@ channel_index = channel_labels.index(snakemake.wildcards.stain)
 
 #member function of floating image
 flo_znimg = ZarrNii.from_path(snakemake.input.ome_zarr, channels=[channel_index])
-ref_znimg = ZarrNii.from_path_as_ref(snakemake.input.ref_nii, channels=[channel_index],chunks=snakemake.params.chunks,zooms=snakemake.params.zooms)
+ref_znimg = ZarrNii.from_path_as_ref(snakemake.input.ref_nii, channels=[channel_index],**snakemake.params.ref_opts)
 
 out_znimg = flo_znimg.apply_transform(Transform.affine_ras_from_txt(snakemake.input.xfm_ras),ref_znimg=ref_znimg)
 

--- a/spimquant/workflow/scripts/affine_to_template_ome_zarr.py
+++ b/spimquant/workflow/scripts/affine_to_template_ome_zarr.py
@@ -12,7 +12,7 @@ channel_index = channel_labels.index(snakemake.wildcards.stain)
 
 
 flo_znimg = ZarrNii.from_path(snakemake.input.ome_zarr, channels=[channel_index])
-ref_znimg = ZarrNii.from_path_as_ref(snakemake.input.ref_nii, channels=[channel_index],chunks=snakemake.params.chunks,zooms=snakemake.params.zooms)
+ref_znimg = ZarrNii.from_path_as_ref(snakemake.input.ref_nii, channels=[channel_index],**snakemake.params.ref_opts)
 
 out_znimg = flo_znimg.apply_transform(Transform.affine_ras_from_txt(snakemake.input.xfm_ras),ref_znimg=ref_znimg)
 

--- a/spimquant/workflow/scripts/deform_to_template_nii.py
+++ b/spimquant/workflow/scripts/deform_to_template_nii.py
@@ -3,7 +3,7 @@ import nibabel as nib
 from  zarrnii import ZarrNii, Transform
 from dask.distributed import Client
 
-client = Client(n_workers=snakemake.threads, threads_per_worker=1,processes=False)
+client = Client(n_workers=4, threads_per_worker=2,processes=False)
 print(client.dashboard_link)
 
 #get channel index from omero metadata
@@ -17,14 +17,14 @@ channel_index = channel_labels.index(snakemake.wildcards.stain)
 flo_znimg = ZarrNii.from_path(snakemake.input.ome_zarr, channels=[channel_index], **snakemake.params.flo_opts)
 ref_znimg = ZarrNii.from_path_as_ref(snakemake.input.ref_nii, channels=[channel_index],**snakemake.params.ref_opts)
 
-deform_znimg = flo_znimg.apply_transform(Transform.displacement_from_nifti(snakemake.input.warp_nii),
+if snakemake.params.do_downsample:
+    flo_ds_znimg = flo_znimg.downsample(**snakemake.params.downsample_opts)
+
+
+deform_znimg = flo_ds_znimg.apply_transform(Transform.displacement_from_nifti(snakemake.input.warp_nii),
                     Transform.affine_ras_from_txt(snakemake.input.xfm_ras),
                     ref_znimg=ref_znimg)
 
-
-if 'downsample_opts' in snakemake.params:
-    print('downsampling before apply transform')
-    deform_znimg = deform_znimg.downsample(**snakemake.params.downsample_opts)
 
 deform_znimg.to_nifti(snakemake.output.nii)
 

--- a/spimquant/workflow/scripts/deform_to_template_nii.py
+++ b/spimquant/workflow/scripts/deform_to_template_nii.py
@@ -1,7 +1,10 @@
 import zarr
 import nibabel as nib
 from  zarrnii import ZarrNii, Transform
-from dask.diagnostics import ProgressBar
+from dask.distributed import Client
+
+client = Client(n_workers=snakemake.threads, threads_per_worker=1,processes=False)
+print(client.dashboard_link)
 
 #get channel index from omero metadata
 zi = zarr.open(snakemake.input.ome_zarr)
@@ -11,17 +14,20 @@ channel_index = channel_labels.index(snakemake.wildcards.stain)
 
 
 #member function of floting image
-flo_znimg = ZarrNii.from_path(snakemake.input.ome_zarr, channels=[channel_index])
-ref_znimg = ZarrNii.from_path_as_ref(snakemake.input.ref_nii, channels=[channel_index],chunks=snakemake.params.chunks,zooms=snakemake.params.zooms)
+flo_znimg = ZarrNii.from_path(snakemake.input.ome_zarr, channels=[channel_index], **snakemake.params.flo_opts)
+ref_znimg = ZarrNii.from_path_as_ref(snakemake.input.ref_nii, channels=[channel_index],**snakemake.params.ref_opts)
 
 deform_znimg = flo_znimg.apply_transform(Transform.displacement_from_nifti(snakemake.input.warp_nii),
                     Transform.affine_ras_from_txt(snakemake.input.xfm_ras),
                     ref_znimg=ref_znimg)
 
-with ProgressBar():
 
-    deform_znimg.to_nifti(snakemake.output.nii, scheduler='single-threaded')
+if 'downsample_opts' in snakemake.params:
+    print('downsampling before apply transform')
+    deform_znimg = deform_znimg.downsample(**snakemake.params.downsample_opts)
+
+deform_znimg.to_nifti(snakemake.output.nii)
 
 
 
-
+client.close()

--- a/spimquant/workflow/scripts/deform_to_template_ome_zarr.py
+++ b/spimquant/workflow/scripts/deform_to_template_ome_zarr.py
@@ -3,7 +3,7 @@ from  zarrnii import ZarrNii, Transform
 from dask.diagnostics import ProgressBar
 
 flo_znimg = ZarrNii.from_path(snakemake.input.ome_zarr, channels=[snakemake.params.channel_index])
-ref_znimg = ZarrNii.from_path_as_ref(snakemake.input.ref_nii, channels=[snakemake.params.channel_index],chunks=snakemake.params.chunks,zooms=snakemake.params.zooms)
+ref_znimg = ZarrNii.from_path_as_ref(snakemake.input.ref_nii, channels=[snakemake.params.channel_index],**snakemake.params.ref_opts)
 
 
 out_znimg = flo_znimg.apply_transform(Transform.displacement_from_nifti(snakemake.input.warp_nii),


### PR DESCRIPTION
also adds dask dashboard link when running.. 

(note: lots of warnings about the nested compute() call, which I use when grabbing the flo chunks in zarrnii apply_transform, should try to address that soon, likely inefficient..)