### PR TITLE
bugfix - was passing channel index for nifti

### DIFF
--- a/spimquant/workflow/scripts/ome_zarr_to_nii.py
+++ b/spimquant/workflow/scripts/ome_zarr_to_nii.py
@@ -42,6 +42,6 @@ zdownsampling = 2**(floor(log2(z_ratio)))
 
 
 with ProgressBar():
-    ZarrNii.from_path(in_zarr,level=level).downsample(along_z=zdownsampling).to_nifti(snakemake.output.nii)
+    ZarrNii.from_path(in_zarr,level=level,channels=[channel_index]).downsample(along_z=zdownsampling).to_nifti(snakemake.output.nii)
 
     


### PR DESCRIPTION
was defaulting to the first channel, which coincidentally worked fine for the lifecanvas data