### PR TITLE
bugfix: console script for spimquant cli had a typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ bokeh = "^3.4.1"
 zarrnii = "0.1.3a1"
 
 [tool.poetry.scripts]
-spimquant = "spimquant.run:main"
+spimquant = "spimquant.run:app.run"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
note: CLI doesn't have any extra optional parameters yet..