### PR TITLE
fixes for zarr with no z downsampling

### DIFF
--- a/spimquant/workflow/rules/import.smk
+++ b/spimquant/workflow/rules/import.smk
@@ -10,7 +10,7 @@ rule get_downsampled_nii:
     input:
         **get_storage_creds(inputs["spim"].path, config["remote_creds"]),
     params:
-        in_zarr=inputs["spim"].path,
+        uri=inputs["spim"].path,
         storage_provider_settings=workflow.storage_provider_settings,  #this  may not be needed anymore ? test with new zarrnii in container..
     output:
         nii=bids(

--- a/spimquant/workflow/rules/segmentation.smk
+++ b/spimquant/workflow/rules/segmentation.smk
@@ -272,7 +272,7 @@ rule dask_threshold:
     input:
         n4=rules.dask_n4.output,
     params:
-        threshold=config["seg_threshold"],
+        threshold=int(config["seg_threshold"]),
         spim_n4_uri=bids(
             root=root_coiled,
             datatype="micr",


### PR DESCRIPTION
- imaris or legacy bigstitcher datasets have this
- these changes are a bit hacky and are a placeholder until I incorporate this behaviour into zarrnii by default..