### PR TITLE
fix units for ds test data

### DIFF
--- a/tests/bids_ds/sub-AS36F2/micr/sub-AS36F2_sample-brain_acq-downsampled_SPIM.ome.zarr/.zattrs
+++ b/tests/bids_ds/sub-AS36F2/micr/sub-AS36F2_sample-brain_acq-downsampled_SPIM.ome.zarr/.zattrs
@@ -42,15 +42,18 @@
         },
         {
           "name": "z",
-          "type": "space"
+          "type": "space",
+          "unit": "millimeter"
         },
         {
           "name": "y",
-          "type": "space"
+          "type": "space",
+          "unit": "millimeter"
         },
         {
           "name": "x",
-          "type": "space"
+          "type": "space",
+          "unit": "millimeter"
         }
       ],
       "datasets": [

--- a/tests/bids_ds_withmri/sub-AS36F2/micr/sub-AS36F2_sample-brain_acq-downsampled_SPIM.ome.zarr/.zattrs
+++ b/tests/bids_ds_withmri/sub-AS36F2/micr/sub-AS36F2_sample-brain_acq-downsampled_SPIM.ome.zarr/.zattrs
@@ -42,15 +42,18 @@
         },
         {
           "name": "z",
-          "type": "space"
+          "type": "space",
+          "unit": "millimeter"
         },
         {
           "name": "y",
-          "type": "space"
+          "type": "space",
+          "unit": "millimeter"
         },
         {
           "name": "x",
-          "type": "space"
+          "type": "space",
+          "unit": "millimeter"
         }
       ],
       "datasets": [

--- a/tests/bids_ds_withmri/sub-AS36F3/micr/sub-AS36F3_sample-brain_acq-downsampled_SPIM.ome.zarr/.zattrs
+++ b/tests/bids_ds_withmri/sub-AS36F3/micr/sub-AS36F3_sample-brain_acq-downsampled_SPIM.ome.zarr/.zattrs
@@ -42,15 +42,18 @@
         },
         {
           "name": "z",
-          "type": "space"
+          "type": "space",
+          "unit": "millimeter"
         },
         {
           "name": "y",
-          "type": "space"
+          "type": "space",
+          "unit": "millimeter"
         },
         {
           "name": "x",
-          "type": "space"
+          "type": "space",
+          "unit": "millimeter"
         }
       ],
       "datasets": [


### PR DESCRIPTION
Test data had no units in the ome zarr, so default assumption of microns was incorrect. This adds the units explicitly. 