### PR TITLE
Ims workflow fixes

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -628,7 +628,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d1/14/7688e984cdd0be1438779825640b943574b89946ed868d76497b3cffb3d5/tensorstore-0.1.83-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: git+https://github.com/khanlab/vesselfm?rev=504baab#504baabb253c2b6bf7d5a4037a93c2f590c9da51
       - pypi: https://files.pythonhosted.org/packages/c5/c1/9c64ed6c2d152b56482bb66297bfc03442d25449bfa91da7bf2e58a80f01/wasmtime-44.0.0-py3-none-manylinux1_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/d5/a2/9b518a863ed0dabc07385f8870f535aee2d0bef08fed87b4d9b0986b7d03/zarrnii-0.19.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/29/1638fce798e7b11fc109b45ed919fbc8bbcd3c5c8814404fa6b42b84e360/zarrnii-0.21.0-py3-none-any.whl
       - pypi: ./
   dev:
     channels:
@@ -1432,7 +1432,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d1/14/7688e984cdd0be1438779825640b943574b89946ed868d76497b3cffb3d5/tensorstore-0.1.83-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: git+https://github.com/khanlab/vesselfm?rev=504baab#504baabb253c2b6bf7d5a4037a93c2f590c9da51
       - pypi: https://files.pythonhosted.org/packages/c5/c1/9c64ed6c2d152b56482bb66297bfc03442d25449bfa91da7bf2e58a80f01/wasmtime-44.0.0-py3-none-manylinux1_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/d5/a2/9b518a863ed0dabc07385f8870f535aee2d0bef08fed87b4d9b0986b7d03/zarrnii-0.19.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/29/1638fce798e7b11fc109b45ed919fbc8bbcd3c5c8814404fa6b42b84e360/zarrnii-0.21.0-py3-none-any.whl
       - pypi: ./
   dev-only:
     channels:
@@ -1731,7 +1731,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/0a/469e2bd01be1490336e6c8707386845655d59261543315778a3ccc7e8019/zarr-3.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d5/a2/9b518a863ed0dabc07385f8870f535aee2d0bef08fed87b4d9b0986b7d03/zarrnii-0.19.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/29/1638fce798e7b11fc109b45ed919fbc8bbcd3c5c8814404fa6b42b84e360/zarrnii-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
       - pypi: ./
   gpu:
@@ -2390,7 +2390,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d1/14/7688e984cdd0be1438779825640b943574b89946ed868d76497b3cffb3d5/tensorstore-0.1.83-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: git+https://github.com/khanlab/vesselfm?rev=504baab#504baabb253c2b6bf7d5a4037a93c2f590c9da51
       - pypi: https://files.pythonhosted.org/packages/c5/c1/9c64ed6c2d152b56482bb66297bfc03442d25449bfa91da7bf2e58a80f01/wasmtime-44.0.0-py3-none-manylinux1_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/d5/a2/9b518a863ed0dabc07385f8870f535aee2d0bef08fed87b4d9b0986b7d03/zarrnii-0.19.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/29/1638fce798e7b11fc109b45ed919fbc8bbcd3c5c8814404fa6b42b84e360/zarrnii-0.21.0-py3-none-any.whl
       - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -13918,7 +13918,7 @@ packages:
 - pypi: ./
   name: spimquant
   version: 0.1.0
-  sha256: 43c87c95395e503226c609cd1fd1bbe9e6d35f9523a5fa787531ab64edd5057f
+  sha256: 40d27671dce69f6a4bf9b7baab7d07c51e5a564cc4d704113873b6e1ef42a224
   requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2025.5-hb700be7_0.conda
   sha256: 7547142ab1352132adf98d555ed955badd96c9f277cbd054ae52f7edd6cf6cb8
@@ -15525,10 +15525,10 @@ packages:
   - pkg:pypi/zarr?source=hash-mapping
   size: 367721
   timestamp: 1777989189792
-- pypi: https://files.pythonhosted.org/packages/d5/a2/9b518a863ed0dabc07385f8870f535aee2d0bef08fed87b4d9b0986b7d03/zarrnii-0.19.7-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/8c/29/1638fce798e7b11fc109b45ed919fbc8bbcd3c5c8814404fa6b42b84e360/zarrnii-0.21.0-py3-none-any.whl
   name: zarrnii
-  version: 0.19.7
-  sha256: 1aeb72b130e031b196c409a27bf26c40e0aef940396f9b3df256fa72683c199d
+  version: 0.21.0
+  sha256: fd32c8b5d9ad27e90c2776b45a65926b77b38040c8cdd7b7c989c813c63caf98
   requires_dist:
   - dask>=2026.3.0
   - h5py>=3.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,9 @@ pyarrow = ">=18.0.0,<19"
 
 [tool.pixi.pypi-dependencies]
 spimquant = { path = ".", editable = true }
-zarrnii = ">=0.19.7,<0.20.0"
-#zarrnii = { git = "https://github.com/khanlab/zarrnii", rev = "main",  editable = true }
-#zarrnii = { path = "../zarrnii", editable = true }
+zarrnii = ">=0.21.0,<0.22.0"
+#zarrnii = { git = "https://github.com/khanlab/zarrnii", rev = "resize-local-mean",  editable = true }
+#zarrnii = { path = "/nfs/khan/trainees/akhan488/apps/zarrnii", editable = true }
 vesselfm = { git = "https://github.com/khanlab/vesselfm", rev = "504baab" }
 h5py = ">=3.14.0"
 simpleitk = ">=2.4.0"

--- a/spimquant/config/snakebids.yml
+++ b/spimquant/config/snakebids.yml
@@ -213,6 +213,11 @@ parse_args:
       - distributed
     default: distributed
 
+  --qc_instance_seg:
+    help: "Generate instance-level QC outputs, including animated gifs (default: %(default)s)"
+    action: store_true
+    default: False
+
   --qc_roi_zoom_bg_n4:
     help: "Use n4 bias-field corrected OME-Zarr as background image in the ROI zoom montage QC figures instead of the raw SPIM (only effective when --correction_method n4) (default: %(default)s)"
     action: store_true

--- a/spimquant/workflow/Snakefile
+++ b/spimquant/workflow/Snakefile
@@ -918,7 +918,7 @@ rule all_qc:
             stain=stains_for_seg,
             desc=config["seg_method"],
         )
-        if do_seg
+        if do_seg and config["qc_instance_seg"]
         else [],
         # Colocalization instance GIFs (per atlas seg, per seg method)
         inputs["spim"].expand(
@@ -946,7 +946,7 @@ rule all_qc:
             template=config["template"],
             desc=config["seg_method"],
         )
-        if do_coloc
+        if do_coloc and config["qc_instance_seg"]
         else [],
 
 

--- a/spimquant/workflow/scripts/n4_biasfield.py
+++ b/spimquant/workflow/scripts/n4_biasfield.py
@@ -4,7 +4,7 @@ if __name__ == "__main__":
     from zarrnii import ZarrNii
     from zarrnii.plugins import N4BiasFieldCorrection
 
-    with get_dask_client(snakemake.config["dask_scheduler"], snakemake.threads):
+    with get_dask_client(snakemake.config["dask_scheduler"], snakemake.threads, threads_per_worker=16):
 
         hires_level = int(snakemake.wildcards.level)
         proc_level = int(snakemake.params.proc_level)
@@ -20,17 +20,23 @@ if __name__ == "__main__":
             chunks=(256,256,256),
             **snakemake.params.zarrnii_kwargs,
         )
+        znimg_lowres = ZarrNii.from_file(
+            snakemake.input.spim,
+            channel_labels=[snakemake.wildcards.stain],
+            level=proc_level,
+            downsample_near_isotropic=True,
+            **snakemake.params.zarrnii_kwargs,
+        )
+
 
         print("compute bias field correction")
 
-        adjusted_chunk = int(
-            snakemake.params.target_chunk_size / (2**adjusted_downsample_factor)
-        )
 
         # Apply bias field correction
         znimg_corrected = znimg.apply_scaled_processing(
             N4BiasFieldCorrection(shrink_factor=snakemake.params.shrink_factor),
-            downsample_factor=adjusted_downsample_factor,
+            lowres_znimg=znimg_lowres,
+            method="map_blocks"
         )
 
         # write to ome_zarr

--- a/spimquant/workflow/scripts/n4_biasfield.py
+++ b/spimquant/workflow/scripts/n4_biasfield.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
             channel_labels=[snakemake.wildcards.stain],
             level=hires_level,
             downsample_near_isotropic=True,
+            chunks=(256,256,256),
             **snakemake.params.zarrnii_kwargs,
         )
 

--- a/spimquant/workflow/scripts/n4_biasfield.py
+++ b/spimquant/workflow/scripts/n4_biasfield.py
@@ -4,7 +4,9 @@ if __name__ == "__main__":
     from zarrnii import ZarrNii
     from zarrnii.plugins import N4BiasFieldCorrection
 
-    with get_dask_client(snakemake.config["dask_scheduler"], snakemake.threads, threads_per_worker=16):
+    with get_dask_client(
+        snakemake.config["dask_scheduler"], snakemake.threads, threads_per_worker=16
+    ):
 
         hires_level = int(snakemake.wildcards.level)
         proc_level = int(snakemake.params.proc_level)
@@ -17,7 +19,7 @@ if __name__ == "__main__":
             channel_labels=[snakemake.wildcards.stain],
             level=hires_level,
             downsample_near_isotropic=True,
-            chunks=(256,256,256),
+            chunks=(256, 256, 256),
             **snakemake.params.zarrnii_kwargs,
         )
         znimg_lowres = ZarrNii.from_file(
@@ -28,15 +30,13 @@ if __name__ == "__main__":
             **snakemake.params.zarrnii_kwargs,
         )
 
-
         print("compute bias field correction")
-
 
         # Apply bias field correction
         znimg_corrected = znimg.apply_scaled_processing(
             N4BiasFieldCorrection(shrink_factor=snakemake.params.shrink_factor),
             lowres_znimg=znimg_lowres,
-            method="map_blocks"
+            method="map_blocks",
         )
 
         # write to ome_zarr

--- a/spimquant/workflow/scripts/ome_zarr_to_nii.py
+++ b/spimquant/workflow/scripts/ome_zarr_to_nii.py
@@ -3,12 +3,13 @@ from dask_setup import get_dask_client
 from zarrnii import ZarrNii
 
 if __name__ == "__main__":
-    with get_dask_client(snakemake.config["dask_scheduler"], snakemake.threads):
+    with get_dask_client("threads", snakemake.threads):
         znimg = ZarrNii.from_file(
             snakemake.input.spim,
             level=int(snakemake.wildcards.level),
             channel_labels=[snakemake.wildcards.stain],
             downsample_near_isotropic=True,
+            chunks=None,
             **snakemake.params.zarrnii_kwargs,
         )
 

--- a/spimquant/workflow/scripts/qc_instance_gif.py
+++ b/spimquant/workflow/scripts/qc_instance_gif.py
@@ -70,6 +70,7 @@ def _load_channel_images(spim_path, channels, level):
             spim_path,
             level=level,
             channel_labels=[ch],
+            **snakemake.params.zarrnii_kwargs,
         )
     return imgs
 
@@ -94,6 +95,7 @@ def _global_norms(imgs, channels):
                     snakemake.input.spim,
                     level=(base_level + extra),
                     channel_labels=[ch],
+                    **snakemake.params.zarrnii_kwargs,
                 )
                 arr = coarse.data.compute()
                 break

--- a/spimquant/workflow/scripts/qc_segmentation_roi_zoom.py
+++ b/spimquant/workflow/scripts/qc_segmentation_roi_zoom.py
@@ -172,8 +172,6 @@ def main():
         spim_sl = spim_crop.data[0, :, :].squeeze().compute()
         spim_sl = _apply_fixed_percentile_norm(spim_sl, glob_lo, glob_hi)
 
-
-
         mask_sl = mask_crop.data[0, :, :].squeeze().compute()
         cached_slices.append((label_name, spim_sl, mask_sl))
 
@@ -185,7 +183,6 @@ def main():
         ax.set_title(label_name, fontsize=7, pad=2)
         ax.set_xticks([])
         ax.set_yticks([])
-
 
     # Hide unused axes
     for i in range(n_rois, n_rows * n_cols):

--- a/spimquant/workflow/scripts/qc_segmentation_roi_zoom.py
+++ b/spimquant/workflow/scripts/qc_segmentation_roi_zoom.py
@@ -159,6 +159,7 @@ def main():
         # get cropped images for this label
         bbox_min, bbox_max = atlas.get_region_bounding_box(region_ids=label_id)
         center_coord = tuple((x + y) / 2 for x, y in zip(bbox_min, bbox_max))
+
         spim_crop = spim_img.crop_centered(
             center_coord,
             patch_size=(snakemake.params.patch_size, snakemake.params.patch_size, 1),
@@ -170,6 +171,9 @@ def main():
 
         spim_sl = spim_crop.data[0, :, :].squeeze().compute()
         spim_sl = _apply_fixed_percentile_norm(spim_sl, glob_lo, glob_hi)
+
+
+
         mask_sl = mask_crop.data[0, :, :].squeeze().compute()
         cached_slices.append((label_name, spim_sl, mask_sl))
 
@@ -181,6 +185,7 @@ def main():
         ax.set_title(label_name, fontsize=7, pad=2)
         ax.set_xticks([])
         ax.set_yticks([])
+
 
     # Hide unused axes
     for i in range(n_rois, n_rows * n_cols):

--- a/spimquant/workflow/scripts/vesselfm.py
+++ b/spimquant/workflow/scripts/vesselfm.py
@@ -10,7 +10,7 @@ with get_dask_client("threads", snakemake.threads):
         level=int(snakemake.wildcards.level),
         channel_labels=[snakemake.wildcards.stain],
         downsample_near_isotropic=True,
-        chunks=(256,256,256),
+        chunks=(256, 256, 256),
         **snakemake.params.zarrnii_kwargs,
     )
     znimg_mask = znimg.segment(VesselFMPlugin, **snakemake.params.vesselfm_kwargs)

--- a/spimquant/workflow/scripts/vesselfm.py
+++ b/spimquant/workflow/scripts/vesselfm.py
@@ -10,6 +10,7 @@ with get_dask_client("threads", snakemake.threads):
         level=int(snakemake.wildcards.level),
         channel_labels=[snakemake.wildcards.stain],
         downsample_near_isotropic=True,
+        chunks=(256,256,256),
         **snakemake.params.zarrnii_kwargs,
     )
     znimg_mask = znimg.segment(VesselFMPlugin, **snakemake.params.vesselfm_kwargs)


### PR DESCRIPTION
- points to latest zarrnii release which has fixes for imaris scaling factors and axes_units
  - all phys units are in mm now, rather than units of the initial imported image
  - uses new map_blocks method for n4_biasfield correction
  - disable qc_instance_seg by default (more for the sake of efficiency)..
  - set chunks=(256,256,256) when reading for segmentation --  note that with recent zarrnii updates, doing this don't rechunk if already set to that chunking.. 