### PR TITLE
make chunks (1x256x256x256) the default

### DIFF
--- a/spimquant/config/snakebids.yml
+++ b/spimquant/config/snakebids.yml
@@ -245,9 +245,9 @@ parse_args:
     help: "Chunk size (c, x, y, z) for intermediate OME-Zarr stores (default: %(default)s)"
     default:
       - 1
-      - 128
-      - 128
-      - 128
+      - 256
+      - 256
+      - 256
     nargs: 4
     type: int
     dest: zarr_store_chunks


### PR DESCRIPTION
since downstream segmentation post-processing works best with thesee chunks (128 ends up with too large a task graph it seems)..